### PR TITLE
Fix possible fix(deps): 3 vulnerable dependencies in go.mod

### DIFF
--- a/appctr/go.mod
+++ b/appctr/go.mod
@@ -33,9 +33,9 @@ require (
 	go.uber.org/goleak v1.3.0 // indirect
 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745 // indirect
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
-	golang.org/x/crypto v0.54.0 // indirect
+	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/mod v0.37.0 // indirect
+	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect


### PR DESCRIPTION
Proposing a fix for something flagged in `appctr/go.mod`. It is around line 1.

The application uses golang.org/x/crypto v0.54.0, which contains a critical flaw (CVE-2026-56854) where source‑address restrictions in authentication Permissions are only enforced for PublicKeyCallback and VerifiedPublicKeyCallback. This allows attackers to bypass IP‑based access controls when using PasswordCallback, KeyboardInteractiveCallback, NoClientAuthCallback, or GSSAPIWithMICConfig.AllowLogin, potentially leading to unauthorized access. The vulnerability is rated CRITICAL due to the possibility of full account compromise. Upgrading to v0.55.0, where the source‑address check is applied to all authentication callbacks, eliminates the issue.

Upgrade vulnerable golang.org/x/crypto and golang.org/x/mod to patched versions.

For reference: rule `CVE-2026-56854`. Rated critical.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
